### PR TITLE
send-cmd should prepend last arg with : only if /\s/

### DIFF
--- a/lib/IRC/Client.pm6
+++ b/lib/IRC/Client.pm6
@@ -357,7 +357,7 @@ method send-cmd ($cmd, *@args is copy, :$prefix = '', :$server) {
         }
     }
     else {
-        @args[*-1] = ':' ~ @args[*-1] if @args && @args[*-1] ~~ /\s/;
+        @args[*-1] = ':' ~ @args[*-1] if @args && @args[*-1] ~~ / ^':' | \s /;
         self!ssay: :$server, join ' ', $cmd, @args;
     }
 }

--- a/lib/IRC/Client.pm6
+++ b/lib/IRC/Client.pm6
@@ -357,7 +357,7 @@ method send-cmd ($cmd, *@args is copy, :$prefix = '', :$server) {
         }
     }
     else {
-        @args[*-1] = ':' ~ @args[*-1] if @args;
+        @args[*-1] = ':' ~ @args[*-1] if @args && @args[*-1] ~~ /\s/;
         self!ssay: :$server, join ' ', $cmd, @args;
     }
 }

--- a/lib/IRC/Client.pm6
+++ b/lib/IRC/Client.pm6
@@ -357,7 +357,7 @@ method send-cmd ($cmd, *@args is copy, :$prefix = '', :$server) {
         }
     }
     else {
-        @args[*-1] = ':' ~ @args[*-1] if @args && @args[*-1] ~~ / ^':' | \s /;
+        @args[*-1] = ':' ~ @args[*-1] if @args && @args[*-1] ~~ / ^':' | ' ' | ^$ /;
         self!ssay: :$server, join ' ', $cmd, @args;
     }
 }


### PR DESCRIPTION
edit: might be best to squash considering the self-bikeshedding I've done with this single line

ideally according to the IRC specifications, `:` is optional if the last argument to a command has no whitespace

This is to help alleviate some difficulties in zoffixznet/perl6-banbot#2

I am not completely sure all servers agree with the IRC specification on `:` however! Hopefully this is safe enough change to make